### PR TITLE
Use <div> instead of <span> when dynamically generating module routes and containers

### DIFF
--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -24,9 +24,9 @@ function getModuleRoutes(stripes) {
         key={module.route}
         render={props => (
           <AddContext context={{ stripes: moduleStripes }}>
-            <span id={`${name}-module-display`} data-module={module.module} data-version={module.version} >
+            <div id={`${name}-module-display`} data-module={module.module} data-version={module.version} >
               <Current {...props} connect={connect} stripes={moduleStripes} />
-            </span>
+            </div>
           </AddContext>
         )}
       />


### PR DESCRIPTION
The `getModuleRoutes` method appears to generate a routing entry for all loaded stripes modules.  It then maps those routes to a container node that sort of functions as a namespace for the different UI modules installed in the Folio instance.
We were using spans here, but it's probably better to use divs to avoid nesting block-level elements inside inline elements.  This isn't blocking anything that we know of, but we stumbled across it while doing some layout work and figured it was worthy of a quick patch.